### PR TITLE
Fix reducedspin and add tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,7 @@ name = "CollectiveSpins"
 uuid = "abf2e61e-3022-5fcf-a868-69d409dee72b"
 
 [deps]
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -10,12 +11,13 @@ QuantumOptics = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
 QuantumOpticsBase = "4f57444f-1401-5e15-980d-4471b28d5678"
 
 [compat]
+Combinatorics = "= 1"
 DiffEqCallbacks = "≥ 2.9.0"
 Optim = "≥ 0.19.3"
 OrdinaryDiffEq = "≥ 5.19.0"
 QuantumOptics = "≥ 0.7.0"
 QuantumOpticsBase = "≥ 0.1.0"
-julia = "≥ 1.0.0"
+julia = "= 1"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/reducedspin.jl
+++ b/src/reducedspin.jl
@@ -1,6 +1,7 @@
 module reducedspin
 
 using QuantumOptics, Base.Cartesian
+using Combinatorics: combinations
 
 export ReducedSpinBasis, reducedspintransition, reducedspinstate, reducedsigmap, reducedsigmam, reducedsigmax, reducedsigmay, reducedsigmaz
 
@@ -10,246 +11,260 @@ using ..interaction, ..system
 
 
 """
-	ReducedSpinBasis(N, M)
+    ReducedSpinBasis(N, M)
 
 Basis for a system of N spin 1/2 systems, up to the M'th excitation.
 """
 mutable struct ReducedSpinBasis{N, M} <: Basis
-	shape::Vector{Int}
-	N::Int
-	M::Int
-	MS::Int
-	indexMapper::Vector{Array{Int, dim} where dim}
-	
-	function ReducedSpinBasis(N::Int, M::Int, MS::Int)
-		if N < 1
-			throw(DimensionMismatch())
-		end
-		if M < 1
-			throw(DimensionMissmatch())
-		end
-		if M < MS
-			throw(DimensionMissmatch())
-		end
-		
-		numberOfStates = sum(binomial(N, k) for k=MS:M)
-		
-		indexMapper = Array{Array{Int, dim} where dim, 1}(undef, M+1)
-		sf = 0
-		for m=MS:M
-			sf, iM = indexMatrix(m, N, sf)			
-			indexMapper[m+1] = iM
-		end
-		new{N, M}([numberOfStates], N, M, MS, indexMapper)
-	end
-end
+    shape::Vector{Int}
+    N::Int
+    M::Int
+    MS::Int
+    indexMapper::Vector{Pair{Vector{Int},Int}}
 
+    function ReducedSpinBasis(N::Int, M::Int, MS::Int)
+        if N < 1
+            throw(DimensionMismatch())
+        end
+        if M < 1
+            throw(DimensionMissmatch())
+        end
+        if M < MS
+            throw(DimensionMissmatch())
+        end
+
+        dim = sum(binomial(N, k) for k=MS:M)
+        inds = Vector{Int}[]
+        for k=MS:M
+            append!(inds, collect(combinations(1:N,k)))
+        end
+        @assert length(inds)==dim
+        indexMapper = (inds .=> [1:dim;])
+        new{N, M}([dim], N, M, MS, indexMapper)
+    end
+end
 ReducedSpinBasis(N::Int, M::Int) = ReducedSpinBasis(N, M, 0)
+function Base.show(stream::IO, b::ReducedSpinBasis)
+    write(stream, "ReducedSpin(N=$(b.N), M=$(b.M), MS=$(b.MS))")
+end
 
 ==(b1::ReducedSpinBasis, b2::ReducedSpinBasis) = (b1.N == b2.N) && (b1.M == b2.M) && (b1.MS == b2.MS)
 
 """
-	indexMatrix(m::Int, N::Int, sf::Int)
-	
-	Function that constructs an array with the states' indices.
-"""
-function indexMatrix(m::Int, N::Int, sf::Int)
-	@eval begin
-		local stateIndex = $sf
-		local A = zeros(Int, [$N for i=1:$m]...)
-		@nloops $m i d->(((d == $m) ? 1 : i_{d+1} + 1):$N) begin
-			stateIndex += 1
-			(@nref $m A d->(i_{$m+1-d})) = stateIndex
-		end
-		return stateIndex, A
-	end
-end
+    index(b::ReducedSpinBasis, x:Vector{Int})
 
-"""
-	index(b::ReducedSpinBasis, x:Vector{Int})
-	
-	Get the state index given excitation's positions.
+    Get the state index given excitation's positions.
 """
 function index(b::ReducedSpinBasis, x::Vector{Int})
-	@assert length(x) <= b.M
-	@assert length(x) >= b.MS
-	
-	index = b.indexMapper[length(x)+1][sort([i for i in x])...]
-	if index == 0
-		throw(BoundsError())
-		else
-		return index
-	end
+    @assert length(x) <= b.M
+    @assert length(x) >= b.MS
+    i = findfirst(y->y[1]==x, b.indexMapper)
+    return b.indexMapper[i][2]
 end
-
+index(b::ReducedSpinBasis, x::Int) = index(b, [x])
 index(b::ReducedSpinBasis, x) = index(b, convert(Vector{Int}, x))
 
 """
-	reducedspintransition(b::ReducedSpinBasis, to::Vector{Int}, from::Vector{Int})
+    reducedspintransition(b::ReducedSpinBasis, to::Vector{Int}, from::Vector{Int})
 
-	Transition operator ``|\\mathrm{to}⟩⟨\\mathrm{from}|``, where to and from are given as vectors denoting the excitations.
+Transition operator ``|\\mathrm{to}⟩⟨\\mathrm{from}|``, where to and from are given as vectors denoting the excitations.
 """
 function reducedspintransition(b::ReducedSpinBasis, to::Vector{Int}, from::Vector{Int})
-	op = SparseOperator(b)
-	op.data[index(b, to), index(b, from)] = 1.
-	op
+    op = SparseOperator(b)
+    op.data[index(b, to), index(b, from)] = 1.
+    op
 end
-
 reducedspintransition(b::ReducedSpinBasis, to, from) = reducedspintransition(b, convert(Vector{Int}, to), convert(Vector{Int}, from))
+reducedspintransition(b::ReducedSpinBasis, to::Int, from::Int) = reducedspintransition(b, [to], [from])
 
 """
-	reducedsigmap(b::ReducedSpinBasis, j::Int)
-	
-	Sigma Plus Operator for the j-th particle.
+    reducedsigmap(b::ReducedSpinBasis, j::Int)
+
+Sigma Plus Operator for the j-th particle.
 """
 function reducedsigmap(b::ReducedSpinBasis, j::Int)
-	N = b.N
-	M = b.M
-	MS = b.MS
-	@assert M != MS
-	
-	op = SparseOperator(b)
-	
-	if (MS == 0) && (M >= 1)
-		op = reducedspintransition(b, [j], [])
-	end
-	
-	for m=(MS+1):M
-		to, from = transitions(m, N, j)
-		for i=1:length(to)
-			op += reducedspintransition(b, to[i], from[i])
-		end
-	end
-	return op
+    N = b.N
+    M = b.M
+    MS = b.MS
+    @assert MS!=M
+
+    op = SparseOperator(b)
+    for m=MS+1:M
+        to, from = transition_idx(b, j, m)
+        for i=1:length(to)
+            op.data[to[i],from[i]] = 1.0
+        end
+    end
+    return op
 end
 
 """
-	reducedsigmam(b::ReducedSpinBasis, j::Int)
-	
-	Sigma Minus Operator for the j-th particle.
+    transition_idx(b, j, m)
+
+Find the indices of all basis states where a transition from the `m-1` excitation
+manifold into the `m` excitation manifold can occur by raising atom `j`
+"""
+function transition_idx(b, j, m)
+    # Find all states with correct number of excitations
+    to_ = filter(x->length(x[1])==m, b.indexMapper)
+    from_ = filter(x->length(x[1])==m-1, b.indexMapper)
+
+    # to all states that involve j but only from states that do not involve j
+    filter!(x->j∈x[1],to_)
+    filter!(x->!(j∈x[1]),from_)
+
+    # Get and return the corresponding indices
+    to = [t[2] for t=to_]
+    from = [f[2] for f=from_]
+    return to, from
+end
+
+
+"""
+    reducedsigmam(b::ReducedSpinBasis, j::Int)
+
+Sigma Minus Operator for the j-th particle.
 """
 function reducedsigmam(b::ReducedSpinBasis, j::Int)
-	return dagger(reducedsigmap(b, j))
+    return dagger(reducedsigmap(b, j))
 end
 
 """
-	reducedsigmax(b::ReducedSpinBasis, j::Int)
-	
-	Sigma-X Operator for the j-th particle.
+    reducedsigmax(b::ReducedSpinBasis, j::Int)
+
+Sigma-X Operator for the j-th particle.
 """
 function reducedsigmax(b::ReducedSpinBasis, j::Int)
-	return reducedsigmap(b, j) + reducedsigmam(b, j)
+    return reducedsigmap(b, j) + reducedsigmam(b, j)
 end
 
 """
-	reducedsigmay(b::ReducedSpinBasis, j::Int)
-	
-	Sigma-Y Operator for the j-th particle.
+    reducedsigmay(b::ReducedSpinBasis, j::Int)
+
+    Sigma-Y Operator for the j-th particle.
 """
 function reducedsigmay(b::ReducedSpinBasis, j::Int)
-	return im*(-reducedsigmap(b, j) + reducedsigmam(b, j))
+    return im*(-reducedsigmap(b, j) + reducedsigmam(b, j))
 end
 
 """
-	reducedsigmaz(b::ReducedSpinBasis, j::Int)
-	
-	Sigma-Z Operator for the j-th particle.
+    reducedsigmaz(b::ReducedSpinBasis, j::Int)
+
+Sigma-Z Operator for the j-th particle.
 """
 function reducedsigmaz(b::ReducedSpinBasis, j::Int)
-	return 2*reducedsigmap(b, j)*reducedsigmam(b, j) - identityoperator(b)
+    return 2*reducedsigmap(b,j)*reducedsigmam(b,j) - one(b)
 end
 
 """
-	transitions(m, N, j)
-	
-	Rasing transitions for the j-th particle from level (m-1) to m, where N is the total number of particles.
+    reducedspinstate(b::ReducedSpinBasis, inds::Vector{Int})
 
+State where the excitations are placed in the atoms given by `inds`. Note, that
+`b.MS <= length(inds) <= b.M` must be satisfied.
+
+# Examples
+```julia-repl
+julia> b = CollectiveSpins.ReducedSpinBasis(4,2)
+ReducedSpin(N=4, M=2, MS=0)
+
+julia> GS = CollectiveSpins.reducedspinstate(b,[]) # get the ground state
+Ket(dim=11)
+  basis: ReducedSpin(N=4, M=2, MS=0)
+ 1.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+
+julia> ψ2 = CollectiveSpins.reducedspinstate(b,[1,2]) # First and second atom excited
+Ket(dim=11)
+  basis: ReducedSpin(N=4, M=2, MS=0)
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 1.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+```
 """
-function transitions(m::Int, N::Int, j::Int)
-	@eval begin
-		local T = Vector[]
-		local F = Vector[]
-		@nloops $(m-1) i d->(((d == $(m-1)) ? 1 : i_{d+1} + 1):$N) begin
-			from = sort([(@ntuple $(m-1) i)...])
-			if !($j in from)
-				to = sort([from; $j])
-				push!(T, to); push!(F, from)
-			end
-		end
-	return T, F
-	end
+function reducedspinstate(b::ReducedSpinBasis, inds::Vector{Int})
+    basisstate(b, index(b, inds))
 end
-
-"""
-	reducedspinstate(b::ReducedSpinBasis, n::Vector{Int})
-
-	State where the system is completely in [...] excitations.
-"""
-function reducedspinstate(b::ReducedSpinBasis, n::Vector{Int})
-	basisstate(b, index(b, n))
-end
-
 reducedspinstate(b::ReducedSpinBasis, n) = reducedspinstate(b, convert(Vector{Int}, n))
+reducedspinstate(b::ReducedSpinBasis, n::Int) = reducedspinstate(b, [n])
 
 """
-	Hamiltonian(S::SpinCollection, M::Int=1)
-	
-	Builds the dipole-dipole Hamiltonian.
-	
-	* S: SpinCollection
-	* M: Number of excitations.
+    Hamiltonian(S::SpinCollection, M::Int=1)
+
+Builds the dipole-dipole Hamiltonian.
+
+# Arguments
+* S: SpinCollection
+* M: Number of excitations.
 """
 function Hamiltonian(S::SpinCollection, M::Int=1)
-	N = length(S.spins)
-	b = ReducedSpinBasis(N, M)
-	sp(j) = reducedsigmap(b, j)
-	sm(j) = reducedsigmam(b, j)
+    N = length(S.spins)
+    b = ReducedSpinBasis(N, M)
+    sp(j) = reducedsigmap(b, j)
+    sm(j) = reducedsigmam(b, j)
 
-	OmegaM = interaction.OmegaMatrix(S)
-	
-	H = SparseOperator(b)
-	
-	for i=1:N, j=1:N
-		if i == j
-			continue
-		else
-			H += OmegaM[i, j]*sp(i)*sm(j)
-		end
-	end
-	
-	return H
+    OmegaM = interaction.OmegaMatrix(S)
+
+    H = SparseOperator(b)
+
+    for i=1:N, j=1:N
+        if i == j
+            continue
+        else
+            H += OmegaM[i, j]*sp(i)*sm(j)
+        end
+    end
+
+    return H
 end
 
 """
-	JumpOperators(S::SpinCollectino, M::Int=1)
-	
-		Gamma Matix and Jump Operators for dipole-dipole interactino.
-		
-		* S: Spin collection.
-		* M: Number of excitations.
+    JumpOperators(S::SpinCollectino, M::Int=1)
+
+Gamma Matix and Jump Operators for dipole-dipole interactino.
+
+# Arguments
+* S: Spin collection.
+* M: Number of excitations.
 """
 function JumpOperators(S::SpinCollection, M::Int=1)
-		N = length(S.spins)
-		b = ReducedSpinBasis(N, M)
+        N = length(S.spins)
+        b = ReducedSpinBasis(N, M)
 
-		sm(j) = reducedsigmam(b, j)
-		Jumps = [ sm(j) for j=1:N]
-		GammaM = interaction.GammaMatrix(S)
-		
-		return GammaM, Jumps
-	end
+        sm(j) = reducedsigmam(b, j)
+        Jumps = [ sm(j) for j=1:N]
+        GammaM = interaction.GammaMatrix(S)
+
+        return GammaM, Jumps
+    end
 
 """
-	time evolution
+    time evolution
 """
-function timeevoltuion(T, system::SpinCollection, psi0::Union{Ket{B}, DenseOperator{B, B}}; fout=nothing, kwargs...) where B <: ReducedSpinBasis
+function timeevolution(T, system::SpinCollection, psi0::Union{Ket{B}, DenseOperator{B, B}}; fout=nothing, kwargs...) where B <: ReducedSpinBasis
 
-	M = isa(psi0, Ket) ? psi.bais.M : psi0.basis_l.M
-	
-	H = Hamiltonian(S, M)
-	GammaM, J = JumpOperators(S. M)
-	
-	return QuantumOptics.timeevolution.master_h(T, psi0, H, J; fout=fout, rates=GammaM, kwargs...)
+    M = isa(psi0, Ket) ? psi.bais.M : psi0.basis_l.M
+
+    H = Hamiltonian(S, M)
+    GammaM, J = JumpOperators(S. M)
+
+    return QuantumOptics.timeevolution.master_h(T, psi0, H, J; fout=fout, rates=GammaM, kwargs...)
 end
 
 end # module

--- a/src/reducedspin.jl
+++ b/src/reducedspin.jl
@@ -119,6 +119,17 @@ function transition_idx(b, j, m)
     return to, from
 end
 
+"""
+    projector_idx(b, j, m)
+
+Find the indices of all basis states in the `m` excitation manifold involving
+the atom `j` in order to build a projector onto the upper state of this atom.
+"""
+function projector_idx(b,j,m)
+    i_ = filter(x->length(x[1])==m, b.indexMapper)
+    filter!(x->j∈x[1],i_)
+    return getindex.(i_,2)
+end
 
 """
     reducedsigmam(b::ReducedSpinBasis, j::Int)
@@ -153,7 +164,14 @@ end
 Sigma-Z Operator for the j-th particle.
 """
 function reducedsigmaz(b::ReducedSpinBasis, j::Int)
-    return 2*reducedsigmap(b,j)*reducedsigmam(b,j) - one(b)
+    proj = SparseOperator(b)
+    for m=b.MS:b.M
+        i = projector_idx(b,j,m)
+        for i_=i
+            proj.data[i_,i_] += 1.0
+        end
+    end
+    return 2*proj - one(b)
 end
 
 """

--- a/test/test_reducedspin.jl
+++ b/test/test_reducedspin.jl
@@ -101,4 +101,44 @@ for m=0:N
     @test expect(SZ,state) == -N+2m
 end
 
+# Test with lower bound
+b_red1 = CollectiveSpins.ReducedSpinBasis(N, 1, 1)
+b_red2 = CollectiveSpins.ReducedSpinBasis(N, 2, 1)
+
+# Subspace and projectors
+tmp = copy(single_exc)
+single_exc = tmp[2:end] # Remove ground state
+b_sub1 = SubspaceBasis(b_full, single_exc)
+b_sub2 = SubspaceBasis(b_full, [single_exc; two_exc])
+@test length(b_red1) == length(b_sub1)
+@test length(b_red2) == length(b_sub2)
+
+P1 = projector(b_sub1, b_full)
+P2 = projector(b_sub2, b_full)
+
+psi1 = P1*single_exc[1]
+psi2 = CollectiveSpins.reducedspinstate(b_red1, [1])
+@test psi1 != psi2
+@test psi1.data == psi2.data
+
+psi1 = P2*two_exc[end] # Corresponds to state where N-1 and N are excited
+psi2 = CollectiveSpins.reducedspinstate(b_red2, [N-1,N])
+@test psi1 != psi2
+@test psi1.data == psi2.data
+
+# Test matrix elements on reduced bases
+sz(i) = embed(b_full, i, sigmaz(SpinBasis(1//2)))
+sp(i) = embed(b_full, i, sigmap(SpinBasis(1//2)))
+for i=1:N
+    @test CollectiveSpins.reducedsigmap(b_red2, i).data == sparse(P2*sp(i)*P2').data
+    @test CollectiveSpins.reducedsigmam(b_red2, i).data == sparse(P2*sp(i)'*P2').data
+    @test CollectiveSpins.reducedsigmaz(b_red1, i).data == sparse(P1*sz(i)*P1').data
+    @test CollectiveSpins.reducedsigmaz(b_red2, i).data == sparse(P2*sz(i)'*P2').data
+end
+
+SZ1 = sum(CollectiveSpins.reducedsigmaz(b_red1, i) for i=1:N)
+@test all([SZ1.data[i,i] for i=1:N] .== -N+2)
+SZ2 = sum(CollectiveSpins.reducedsigmaz(b_red2, i) for i=1:N)
+@test all([SZ2.data[i,i] for i=1:length(b_red2)] .== [[-2.0 for i=1:N]; zeros(binomial(N,2))])
+
 end #testset

--- a/test/test_reducedspin.jl
+++ b/test/test_reducedspin.jl
@@ -26,7 +26,7 @@ end
 
 # Subspace and projectors
 b_sub1 = SubspaceBasis(b_full, single_exc)
-b_sub2 = SubspaceBasis(b_full, [two_exc; single_exc])
+b_sub2 = SubspaceBasis(b_full, [single_exc; two_exc])
 @test length(b_red1) == length(b_sub1)
 @test length(b_red2) == length(b_sub2)
 
@@ -39,9 +39,27 @@ psi2 = CollectiveSpins.reducedspinstate(b_red1, [1])
 @test psi1.data == psi2.data
 
 psi1 = P2*two_exc[end] # Corresponds to state where N-1 and N are excited
-psi2 = CollectiveSpins.reducedspinstate(b_red2, [1,2]) # Need to check against 1, 2 excited due to inverse order of tensor product
+psi2 = CollectiveSpins.reducedspinstate(b_red2, [N-1,N])
 @test psi1 != psi2
 @test psi1.data == psi2.data
+
+# Test matrix elements on reduced bases
+sz(i) = embed(b_full, i, sigmaz(SpinBasis(1//2)))
+sp(i) = embed(b_full, i, sigmap(SpinBasis(1//2)))
+for i=1:N
+    @test CollectiveSpins.reducedsigmap(b_red1, i).data == sparse(P1*sp(i)*P1').data
+    @test CollectiveSpins.reducedsigmam(b_red1, i).data == sparse(P1*sp(i)'*P1').data
+    @test CollectiveSpins.reducedsigmap(b_red2, i).data == sparse(P2*sp(i)*P2').data
+    @test CollectiveSpins.reducedsigmam(b_red2, i).data == sparse(P2*sp(i)'*P2').data
+    @test CollectiveSpins.reducedsigmaz(b_red1, i).data == sparse(P1*sz(i)*P1').data
+    @test CollectiveSpins.reducedsigmaz(b_red2, i).data == sparse(P2*sz(i)'*P2').data
+end
+
+i=2
+j=4
+tmp = CollectiveSpins.reducedsigmap(b_red2,i)*CollectiveSpins.reducedsigmap(b_red2,j)*CollectiveSpins.reducedspinstate(b_red2,[])
+ind = findfirst(!iszero, tmp.data)
+@test b_red2.indexMapper[findfirst(y->y[2]==ind, b_red2.indexMapper)][1] == [i,j]
 
 # Test a full example
 N = 8     # Number of spins
@@ -63,12 +81,24 @@ H_drive = eta*sum(sx(j) for j=1:N)
 H_dipole = CollectiveSpins.reducedspin.Hamiltonian(S, M)
 Gammas, Jumps = CollectiveSpins.reducedspin.JumpOperators(S, M)
 
-
 # Time Evolution
 T = [0:0.05:3.;]
 psi0 = CollectiveSpins.reducedspinstate(b, []) # start in the ground state
 tout, rho = QuantumOptics.timeevolution.master(T, psi0, H_drive + H_dipole, Jumps; rates=Gammas)
 
-SZ = 0.5*sum(CollectiveSpins.reducedsigmaz(b, j) for j=1:N)
+# Test sigmaz
+N = 4
+M = 4
+b_red = CollectiveSpins.ReducedSpinBasis(N,M)
+SZ = sum(CollectiveSpins.reducedsigmaz(b_red,j) for j=1:N)
+
+@test sum(SZ.data)==0
+sz_diag = [SZ.data[i,i] for i=1:2^N]
+for m=0:N
+    inds = findall(isequal(-N+2m),sz_diag)
+    @test length(inds) == binomial(N,m)
+    state = CollectiveSpins.reducedspinstate(b_red, [1:m;])
+    @test expect(SZ,state) == -N+2m
+end
 
 end #testset


### PR DESCRIPTION
This patches a bug in `reducedspin` giving wrong matrix elements for Pauli operators.
@lostermann a brief review would be welcome.